### PR TITLE
Add support for null defaults on properties not marked as nullable

### DIFF
--- a/.changeset/orange-olives-cheer.md
+++ b/.changeset/orange-olives-cheer.md
@@ -1,0 +1,5 @@
+---
+"@tim-smart/openapi-gen": patch
+---
+
+Add support for null defaults on properties not marked as nullable


### PR DESCRIPTION
This adds support for `"properties"` which are not properly marked as `nullable` but are in fact nullable.

In the below example, the property has an explicit default of `null` but is not marked as nullable. Previously, this would fail to generate an `Schema.optionalWith` property.

```json
{
  "properties": {
    "citations": {
      "anyOf": ["..."],
      "default": null,
      "title": "Citations"
    }
  }
}
```