### PR TITLE
Fix the type of nullable properties

### DIFF
--- a/.changeset/long-balloons-drive.md
+++ b/.changeset/long-balloons-drive.md
@@ -1,0 +1,5 @@
+---
+"@tim-smart/openapi-gen": patch
+---
+
+Fix the type of nullable properties to be wrapped by `Schema.NullOr`

--- a/src/JsonSchemaGen.ts
+++ b/src/JsonSchemaGen.ts
@@ -280,7 +280,7 @@ const make = Effect.gen(function* () {
       // Handle the special case where the `default` value of the property
       // was set to `null`, but the property was not properly marked as `nullable`
       if (options.isNullable && options.default === null) {
-        return `${S}.optionalWith(${S}.NullOr(${source}), { nullable: true, default: () => null })`
+        return `${S}.optionalWith(${S}.NullOr(${source}), { default: () => null })`
       }
       const defaultSource =
         options.default !== undefined && options.default !== null

--- a/src/JsonSchemaGen.ts
+++ b/src/JsonSchemaGen.ts
@@ -280,7 +280,7 @@ const make = Effect.gen(function* () {
       // Handle the special case where the `default` value of the property
       // was set to `null`, but the property was not properly marked as `nullable`
       if (options.isNullable && options.default === null) {
-        return `${S}.optionalWith(${source}, { nullable: true, default: () => null })`
+        return `${S}.optionalWith(${S}.NullOr(${source}), { nullable: true, default: () => null })`
       }
       const defaultSource =
         options.default !== undefined && options.default !== null


### PR DESCRIPTION
Adding a `default: () => null` to properties that cannot be assigned to null does not work because the `default` _must_ conform to the type wrapped by `optionalWith`.

![image](https://github.com/user-attachments/assets/0db3020b-53e5-4ff5-87e7-c1ee6232559a)

This PR fixes the issue by wrapping properties with a `default: null` in `NullOr`.