### PR TITLE
fix edgecase with minItems to prevent schema error

### DIFF
--- a/src/JsonSchemaGen.ts
+++ b/src/JsonSchemaGen.ts
@@ -380,8 +380,7 @@ const make = Effect.gen(function* () {
         case "array": {
           const nonEmpty =
             typeof schema.minItems === "number" &&
-            schema.minItems === 1 &&
-            schema.maxItems === undefined
+            schema.minItems > 0;
           return toSource(
             importName,
             itemsSchema(schema.items),
@@ -639,7 +638,7 @@ export const layerTransformerSchema = Layer.sync(JsonSchemaTransformer, () => {
     },
     onArray({ importName, schema, item, nonEmpty }) {
       const modifiers: Array<string> = []
-      if ("minItems" in schema && !nonEmpty) {
+      if ("minItems" in schema && nonEmpty) {
         modifiers.push(`${importName}.minItems(${schema.minItems})`)
       }
       if ("maxItems" in schema) {


### PR DESCRIPTION
when describing an array schema with `minItems: 0` the code currently generates 
```ts
Schema.minItems(0)
```

which always throws on construction: https://effect.website/play#fb12f4b23d64

---

this pr fixes that and all more consistently uses the `NonEmptyArray` schemas where the minItem is non-zero