### PR TITLE
Support reference objects in responses

### DIFF
--- a/.changeset/curly-toys-swim.md
+++ b/.changeset/curly-toys-swim.md
@@ -1,0 +1,5 @@
+---
+"@tim-smart/openapi-gen": patch
+---
+
+Support reference objects in OpenApi responses

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -198,6 +198,9 @@ export const make = Effect.gen(function* () {
             let defaultSchema: string | undefined
             Object.entries(operation.responses ?? {}).forEach(
               ([status, response]) => {
+                if ("$ref" in response) {
+                  response = resolveRef(response.$ref as string)
+                }
                 if (response.content?.["application/json"]?.schema) {
                   const schemaName = gen.addSchema(
                     `${schemaId}${status}`,
@@ -266,7 +269,7 @@ export class OpenApiTransformer extends Context.Tag("OpenApiTransformer")<
       operations: ReadonlyArray<ParsedOperation>,
     ) => string
   }
->() {}
+>() { }
 
 export const layerTransformerSchema = Layer.sync(OpenApiTransformer, () => {
   const operationsToInterface = (


### PR DESCRIPTION
The responses field of OpenApi operations can contain [reference objects](https://swagger.io/specification/#:~:text=octet%2Dstream.-,Responses%20Object,-A%20container%20for).