### PR TITLE
Support resolving nested response object references and empty responses

### DIFF
--- a/.changeset/yellow-kids-decide.md
+++ b/.changeset/yellow-kids-decide.md
@@ -1,0 +1,5 @@
+---
+"@tim-smart/openapi-gen": patch
+---
+
+Support resolving nested response object references and empty responses

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -50,7 +50,7 @@ interface ParsedOperation {
   readonly pathTemplate: string
   readonly successSchemas: ReadonlyMap<string, string>
   readonly errorSchemas: ReadonlyMap<string, string>
-  readonly voidSchemas: ReadonlyMap<string, string>
+  readonly voidSchemas: ReadonlySet<string>
 }
 
 export const make = Effect.gen(function* () {
@@ -124,7 +124,7 @@ export const make = Effect.gen(function* () {
               payloadFormData: false,
               successSchemas: new Map(),
               errorSchemas: new Map(),
-              voidSchemas: new Map(),
+              voidSchemas: new Set(),
               paramsOptional: true,
             }
             const schemaId = identifier(operation.operationId ?? path)
@@ -225,7 +225,7 @@ export const make = Effect.gen(function* () {
                   }
                 }
                 if (!response.content) {
-                  op.voidSchemas.set(status.toLowerCase(), "S.Void")
+                  op.voidSchemas.add(status.toLowerCase())
                 }
               },
             )
@@ -402,7 +402,7 @@ ${clientErrorSource(name)}`
     operation.errorSchemas.forEach((schema, status) => {
       decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
     })
-    operation.voidSchemas.forEach((_, status) => {
+    operation.voidSchemas.forEach((status) => {
       decodes.push(`"${status}": () => Effect.void`)
     })
     decodes.push(`orElse: unexpectedStatus`)

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -402,7 +402,7 @@ ${clientErrorSource(name)}`
     operation.errorSchemas.forEach((schema, status) => {
       decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
     })
-    operation.voidSchemas.forEach((schema, status) => {
+    operation.voidSchemas.forEach((_, status) => {
       decodes.push(`"${status}": () => Effect.void`)
     })
     decodes.push(`orElse: unexpectedStatus`)

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -198,17 +198,13 @@ export const make = Effect.gen(function* () {
             let defaultSchema: string | undefined
             Object.entries(operation.responses ?? {}).forEach(
               ([status, response]) => {
-                if ("$ref" in response) {
+                while ("$ref" in response) {
                   response = resolveRef(response.$ref as string)
                 }
                 if (response.content?.["application/json"]?.schema) {
-                  let schema = response.content["application/json"].schema
-                  while ("$ref" in schema) {
-                    schema = resolveRef(schema.$ref)
-                  }
                   const schemaName = gen.addSchema(
                     `${schemaId}${status}`,
-                    schema,
+                    response.content["application/json"].schema,
                     context,
                     true,
                   )

--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -12,7 +12,6 @@ import { camelize, identifier, nonEmptyString, toComment } from "./Utils.js"
 import { convertObj } from "swagger2openapi"
 import * as Context from "effect/Context"
 import * as Option from "effect/Option"
-import * as util from "node:util"
 
 const methodNames: ReadonlyArray<OpenAPISpecMethodName> = [
   "get",


### PR DESCRIPTION
- Supports nested `$ref` objects in response objects
- Supports empty response objects (i.e. `204`)
```yaml
# Example from Spotify OpenApi spec
responses:
  '204':
    description: Command received
```