### PR TITLE
Ensure 4xx Class Generated Event When Schema Empty

### DIFF
--- a/src/JsonSchemaGen.ts
+++ b/src/JsonSchemaGen.ts
@@ -7,6 +7,7 @@ import * as Arr from "effect/Array"
 import { pipe } from "effect/Function"
 import { identifier, nonEmptyString, toComment } from "./Utils"
 import * as Struct from "effect/Struct"
+import * as Data from "effect/Data"
 
 const make = Effect.gen(function* () {
   const store = new Map<string, JsonSchema.JsonSchema>()
@@ -160,7 +161,9 @@ const make = Effect.gen(function* () {
       isClass,
       isEnum,
     })
-    return toSource(importName, schema, name, topLevel).pipe(
+    return toSource(importName, Object.keys(schema).length ? schema : {
+      properties: {},
+    } as JsonSchema.JsonSchema, name, topLevel).pipe(
       Option.map((source) =>
         transformer.onTopLevel({
           importName,


### PR DESCRIPTION
Closes #67

Solves issue wherein `Schema.Class` gen was being skipped for 4xx responses with empty schemas. Was able to resolve by passing in an empty object JSON schema as a fallback schema in the `toSource` call.