### PR TITLE
fix: handle boolean schemas in OpenAPI 3.1 specifications

### DIFF
--- a/test-fixtures/boolean-schema-test.json
+++ b/test-fixtures/boolean-schema-test.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Boolean Schema Test API",
+    "version": "1.0.0",
+    "description": "Test cases for boolean schema support in OpenAPI 3.1"
+  },
+  "paths": {
+    "/test-tuple-false": {
+      "get": {
+        "operationId": "getTupleFalse",
+        "summary": "Test tuple with items: false (no additional items)",
+        "responses": {
+          "200": {
+            "description": "Strict tuple [integer, string]",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": false,
+                  "prefixItems": [
+                    { "type": "integer" },
+                    { "type": "string" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/test-tuple-true": {
+      "get": {
+        "operationId": "getTupleTrue",
+        "summary": "Test tuple with items: true (any additional items)",
+        "responses": {
+          "200": {
+            "description": "Tuple with any additional items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": true,
+                  "prefixItems": [
+                    { "type": "integer" },
+                    { "type": "string" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/test-nested-tuple": {
+      "get": {
+        "operationId": "getNestedTuple",
+        "summary": "Test nested arrays with boolean schemas",
+        "responses": {
+          "200": {
+            "description": "Array of strict tuples",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": false,
+                    "prefixItems": [
+                      { "type": "number", "description": "timestamp" },
+                      { "type": "number", "description": "value" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/test-mixed-schemas": {
+      "get": {
+        "operationId": "getMixedSchemas",
+        "summary": "Test response with both boolean and object schemas",
+        "responses": {
+          "200": {
+            "description": "Mixed schema types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "strictTuple": {
+                      "type": "array",
+                      "items": false,
+                      "prefixItems": [
+                        { "type": "string" }
+                      ]
+                    },
+                    "openTuple": {
+                      "type": "array",
+                      "items": true,
+                      "prefixItems": [
+                        { "type": "string" }
+                      ]
+                    },
+                    "normalArray": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-fixtures/test-boolean-schemas.sh
+++ b/test-fixtures/test-boolean-schemas.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Test script for boolean schema support
+
+echo "Testing Boolean Schema Support in OpenAPI 3.1"
+echo "============================================="
+echo ""
+
+# Build the project
+echo "Building project..."
+npm run build:ts > /dev/null 2>&1
+
+# Test 1: Boolean schema test fixture
+echo "Test 1: Boolean schema test fixture"
+node dist/main.js -s test-fixtures/boolean-schema-test.json -n BooleanSchemaTestClient > /tmp/boolean-test-output.ts 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ SUCCESS: Generated $(wc -l < /tmp/boolean-test-output.ts) lines of code"
+else
+    echo "❌ FAILED"
+    cat /tmp/boolean-test-output.ts | grep -A2 "ERROR"
+    exit 1
+fi
+
+echo ""
+
+# Test 2: S2 OpenAPI spec (real-world case)
+echo "Test 2: S2 OpenAPI spec (real-world case)"
+if [ -f /tmp/s2-openapi.json ]; then
+    node dist/main.js -s /tmp/s2-openapi.json -n S2Client > /tmp/s2-test-output.ts 2>&1
+    if [ $? -eq 0 ]; then
+        echo "✅ SUCCESS: Generated $(wc -l < /tmp/s2-test-output.ts) lines of code"
+    else
+        echo "❌ FAILED"
+        cat /tmp/s2-test-output.ts | grep -A2 "ERROR"
+        exit 1
+    fi
+else
+    echo "⚠️  SKIPPED: S2 spec not found at /tmp/s2-openapi.json"
+fi
+
+echo ""
+echo "All tests passed! ✅"


### PR DESCRIPTION
## Summary

This PR fixes a bug where the generator crashes on valid OpenAPI 3.1 specifications that use boolean schemas (`"items": false` or `"items": true`).

Fixes #75

## Problem

OpenAPI 3.1 adopted JSON Schema 2020-12, which allows boolean schemas. When defining strict tuples:
- `"items": false` means no additional items beyond `prefixItems` are allowed
- `"items": true` means any additional items are allowed

The generator was crashing with:
```
TypeError: Cannot use 'in' operator to search for 'type' in false
```

## Solution

Added proper handling for boolean schemas throughout the codebase:

1. **Type guards in `cleanupSchema()`** - Check if schema is boolean/object before property access
2. **Early returns in `addRefs()`** - Skip processing for non-object schemas
3. **Boolean handling in `toSource()`** - Convert true to Unknown, false returns none
4. **Updated `itemsSchema()`** - Handle boolean values for items
5. **Added `onUnknown()` transformer** - Generate proper types for `true` schemas

## Testing

- ✅ Tested with minimal reproduction from issue #75
- ✅ Tested with S2 StreamStore OpenAPI spec (real-world case with 983 lines generated)
- ✅ Added comprehensive test fixtures for boolean schema validation
- ✅ All existing functionality preserved (backward compatible)

## Test Fixtures Added

Created `test-fixtures/boolean-schema-test.json` with test cases for:
- Strict tuples with `"items": false`
- Open tuples with `"items": true`
- Nested arrays with boolean schemas
- Mixed schemas combining boolean and object schemas

## Minimal Reproduction

Repository with minimal repro: https://github.com/schickling-repros/openapi-gen-boolean-schema-bug

Before fix:
```bash
npx @tim-smart/openapi-gen -s minimal-repro.json -n TestClient
# TypeError: Cannot use 'in' operator to search for 'type' in false
```

After fix:
```bash
npx @tim-smart/openapi-gen -s minimal-repro.json -n TestClient
# ✅ Successfully generates client code
```