### PR TITLE
feat: add application/x-www-form-urlencoded request body support

### DIFF
--- a/src/OpenApi.ts
+++ b/src/OpenApi.ts
@@ -41,6 +41,7 @@ interface ParsedOperation {
   readonly cookies: ReadonlyArray<string>
   readonly payload?: string
   readonly payloadFormData: boolean
+  readonly payloadUrlEncoded: boolean
   readonly pathIds: ReadonlyArray<string>
   readonly pathTemplate: string
   readonly successSchemas: ReadonlyMap<string, string>
@@ -116,6 +117,7 @@ export const make = Effect.gen(function* () {
               headers: [],
               cookies: [],
               payloadFormData: false,
+              payloadUrlEncoded: false,
               successSchemas: new Map(),
               errorSchemas: new Map(),
               voidSchemas: new Set(),
@@ -191,6 +193,16 @@ export const make = Effect.gen(function* () {
                 context,
               )
               op.payloadFormData = true
+            } else if (
+              operation.requestBody?.content?.["application/x-www-form-urlencoded"]
+            ) {
+              op.payload = gen.addSchema(
+                `${schemaId}Request`,
+                operation.requestBody.content["application/x-www-form-urlencoded"]
+                  .schema as any,
+                context,
+              )
+              op.payloadUrlEncoded = true
             }
             let defaultSchema: string | undefined
             Object.entries(operation.responses ?? {}).forEach(
@@ -396,6 +408,10 @@ ${clientErrorSource(name)}`
     if (operation.payloadFormData) {
       pipeline.push(
         `HttpClientRequest.bodyFormDataRecord(${payloadVarName} as any)`,
+      )
+    } else if (operation.payloadUrlEncoded) {
+      pipeline.push(
+        `HttpClientRequest.bodyUrlParams(${payloadVarName} as any)`,
       )
     } else if (operation.payload) {
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(${payloadVarName})`)


### PR DESCRIPTION
## Summary

- Adds support for `application/x-www-form-urlencoded` content type in OpenAPI request bodies
- Emits `HttpClientRequest.bodyUrlParams()` for these endpoints, alongside the existing `bodyJsonUnsafe()` (JSON) and `bodyFormDataRecord()` (multipart)

## Motivation

APIs like the Slack Web API send the majority of requests as URL-encoded form data, not JSON. The java-slack-sdk uses `FormBody` (url-encoded) for 324 of its 330 methods. Currently, specs for these APIs must choose between `application/json` (which some endpoints reject) or `multipart/form-data` (which creates multipart boundaries that some endpoints also reject).

This change adds the missing third option so specs can accurately declare `application/x-www-form-urlencoded` and get the correct encoding.

## Test plan

- [x] Verified against Slack Web API: `auth.test`, `conversations.list`, `chat.postMessage`, `files.getUploadURLExternal`, `reactions.add`, `search.messages` all work correctly with `bodyUrlParams`
- [x] Existing `application/json` and `multipart/form-data` paths unchanged
- [x] Build passes (`npm run build`)